### PR TITLE
Added course baskets for mandatory courses

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/design.css
+++ b/design.css
@@ -129,7 +129,7 @@ tr th:first-child{
     border-radius: 10px;
     height:30px;
     padding: 10px;
-    width: 100px;
+    width: 150px;
     text-align: center;
     margin-left: 10px;
     margin-right: 20px;

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
       </datalist>
       <button class="code-add" onclick="addCourse();">Add</button>
       <button class="code-remove" onclick="removeCourse();">Remove</button>
+      <p>You can select course baskets by using &lt;SUBJECT&gt;-MAJORS(&lt;YEAR&gt;) or CORE(&lt;YEAR&gt;) e.g. use PHY-MAJORS(3RD)</p>
+      <!-- <button class="code-add" onclick="addCourse()">Add</button> --> 
     </div>
 
     <div id="selected-courses">

--- a/table.js
+++ b/table.js
@@ -3,14 +3,14 @@ let selected_courses = [];
 let all_courses = [];
 let all_packages = {'PHY-MAJORS(4TH)':['PHY401','PHY402','PHY403','PHY411'], 
                     'PHY-MAJORS(3RD)':['PHY301','PHY302','PHY310','PHY311','PHY303'],
-                    'CORE(2ND)':['PHY201','BIO201','CHM201','MTH201'],
+                    'CORE(2ND)':['PHY201','BIO201','CHM201','MTH201','PHY201(T)','BIO201(T)','CHM201(T)','MTH201(T)'],
                     'BIO-MAJORS(4TH)':['BIO401','BIO402','BIO411'],
                     'BIO-MAJORS(3RD)':['BIO301','BIO302','BIO303','BIO311'],
                     'MTH-MAJORS(3RD)':['MTH301','MTH302','MTH303','MTH304'],
                     'MTH-MAJORS(4TH)':['MTH402','MTH403'],
                     'CHM-MAJORS(3RD)':['CHM301','CHM302','CHM303','CHM311'], 
                     'CHM-MAJORS(4TH)':['CHM401','CHM411','CH402'],
-                    'CORE(1ST)':['PHY101','CHM101','BIO101','MTH101']}
+                    'CORE(1ST)':['PHY101','CHM101','BIO101','MTH101','PHY101(T)','CHM101(T)','BIO101(T)','MTH101(T)']}
 let package_courses = Object.keys(all_packages);
 let tbl;
 

--- a/table.js
+++ b/table.js
@@ -1,7 +1,19 @@
 let reftable;
 let selected_courses = [];
 let all_courses = [];
+let all_packages = {'PHY-MAJORS(4TH)':['PHY401','PHY402','PHY403','PHY411'], 
+                    'PHY-MAJORS(3RD)':['PHY301','PHY302','PHY310','PHY311','PHY303'],
+                    'CORE(2ND)':['PHY201','BIO201','CHM201','MTH201'],
+                    'BIO-MAJORS(4TH)':['BIO401','BIO402','BIO411'],
+                    'BIO-MAJORS(3RD)':['BIO301','BIO302','BIO303','BIO311'],
+                    'MTH-MAJORS(3RD)':['MTH301','MTH302','MTH303','MTH304'],
+                    'MTH-MAJORS(4TH)':['MTH402','MTH403'],
+                    'CHM-MAJORS(3RD)':['CHM301','CHM302','CHM303','CHM311'], 
+                    'CHM-MAJORS(4TH)':['CHM401','CHM411','CH402'],
+                    'CORE(1ST)':['PHY101','CHM101','BIO101','MTH101']}
+let package_courses = Object.keys(all_packages);
 let tbl;
+
 
 /* HTML Table Construction helper functions*/
   function addCell(tr, val) {
@@ -70,7 +82,6 @@ let tbl;
     }
 
     all_courses = [...new Set(all_courses)].filter(item => item !== "").filter(item => item !== "-").sort();
-    
     return ref_rows;
 }
 
@@ -121,6 +132,9 @@ let tbl;
     for(option of all_courses){
       options += '<option value="' + option + '" />';
     }
+    for(option of package_courses){
+      options += '<option value="' + option + '" />';
+    }
     document.getElementById("code-picker").innerHTML = options;
   }
 
@@ -159,9 +173,13 @@ let tbl;
     var inputVal = document.getElementsByClassName("code-picker")[0].value.trim();
     if((all_courses.includes(inputVal)) && !(selected_courses.includes(inputVal))) {
       selected_courses.push(inputVal);
+    }
+    if (package_courses.includes(inputVal)) {
+      selected_courses = new Set(selected_courses.concat(all_packages[inputVal]));
+      selected_courses = Array.from(selected_courses);
+    }
       updateCourse();
       generate();
-    }
 
     document.getElementsByClassName("code-picker")[0].value = "";
   }
@@ -170,9 +188,12 @@ let tbl;
     var inputVal = document.getElementsByClassName("code-picker")[0].value.trim();
     if(selected_courses.includes(inputVal)) {
       selected_courses = selected_courses.filter(item => item !== inputVal);
-      updateCourse();
-      generate();
     }
+    if(package_courses.includes(inputVal)) { 
+      selected_courses = selected_courses.filter(item => !(all_packages[inputVal].includes(item)))
+    }
+    updateCourse();
+    generate();
 
     document.getElementsByClassName("code-picker")[0].value = "";
   }

--- a/table.js
+++ b/table.js
@@ -173,13 +173,17 @@ let tbl;
     var inputVal = document.getElementsByClassName("code-picker")[0].value.trim();
     if((all_courses.includes(inputVal)) && !(selected_courses.includes(inputVal))) {
       selected_courses.push(inputVal);
-    }
-    if (package_courses.includes(inputVal)) {
-      selected_courses = new Set(selected_courses.concat(all_packages[inputVal]));
-      selected_courses = Array.from(selected_courses);
-    }
+
       updateCourse();
       generate();
+    }
+    else if (package_courses.includes(inputVal)) {
+      selected_courses = new Set(selected_courses.concat(all_packages[inputVal]));
+      selected_courses = Array.from(selected_courses);
+
+      updateCourse();
+      generate();
+    }
 
     document.getElementsByClassName("code-picker")[0].value = "";
   }
@@ -188,12 +192,18 @@ let tbl;
     var inputVal = document.getElementsByClassName("code-picker")[0].value.trim();
     if(selected_courses.includes(inputVal)) {
       selected_courses = selected_courses.filter(item => item !== inputVal);
+
+       updateCourse();
+       generate();
+
     }
-    if(package_courses.includes(inputVal)) { 
-      selected_courses = selected_courses.filter(item => !(all_packages[inputVal].includes(item)))
+    else if(package_courses.includes(inputVal)) { 
+      selected_courses = selected_courses.filter(item => !(all_packages[inputVal].includes(item)));
+     
+      updateCourse();
+      generate();
+
     }
-    updateCourse();
-    generate();
 
     document.getElementsByClassName("code-picker")[0].value = "";
   }


### PR DESCRIPTION
Added course baskets for mandatory courses that can be accessed using $SUBJECT- MAJORS($YEAR)/CORE($YEAR) in the dropdown menu.
Removing a course basket removes all the courses in that basket, even if they were selected individually.
Would require some changes for next semester's courses, but that might get solved with the parsing issue. 
Changed the width of the input field to 150px from 100 px to allow for slightly larger names of baskets.